### PR TITLE
Example installation steps for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ them to any POSIX environment that has Bash installed.
 - Make `kubectx` and `kubens` executable (`chmod +x ...`)
 - Figure out how to install bash/zsh/fish [completion scripts](completion/).
 
+Example installation steps:
+
+``` bash
+sudo git clone https://github.com/ahmetb/kubectx /opt/kubectx
+sudo ln -s /opt/kubectx/kubectx /usr/local/bin/kubectx
+sudo ln -s /opt/kubectx/kubens /usr/local/bin/kubens
+```
+
 -----
 
 ####  Users


### PR DESCRIPTION
Example installation steps for Linux make it easier to install this package faster.

I'm not 100% sure that the `/opt` directory is the best place to put it, but I wanted to avoid injecting `utils.bash` into `/usr/local/bin` directory.